### PR TITLE
update wordpress.org contributor list, sync readme with wordpress.org

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Storefront Footer Bar ===
-Contributors: jameskoster, woothemes
+Contributors: woocommerce,automattic,jameskoster,woothemes
 Tags: woocommerce, ecommerce, storefront, footer, widgets
 Requires at least: 4.1
 Tested up to: 4.9


### PR DESCRIPTION
This PR updates the WordPress.org `readme.txt` to make `woocommerce` the `Developer` of the plugin.

ref: p1596823265254600-sl