### PR TITLE
Remove obsolete custom JS file for preview in the Customizer

### DIFF
--- a/storefront-footer-bar.php
+++ b/storefront-footer-bar.php
@@ -179,7 +179,6 @@ final class Storefront_Footer_Bar {
 		if ( 'Storefront' == $theme->name || 'storefront' == $theme->template && apply_filters( 'storefront_footer_bar_supported', true ) ) {
 			add_action( 'wp_enqueue_scripts',       array( $this, 'sfb_styles' ),                       999 );
 			add_action( 'customize_register',       array( $this, 'sfb_customize_register' ) );
-			add_action( 'customize_preview_init',   array( $this, 'sfb_customize_preview_js' ) );
 			add_action( 'storefront_before_footer', array( $this, 'sfb_footer_bar' ),                   10 );
 			add_action( 'init',	                    array( $this, 'default_theme_mod_values' ),         99 );
 			add_action( 'customize_register',       array( $this, 'edit_default_customizer_settings' ), 99 );
@@ -296,7 +295,6 @@ final class Storefront_Footer_Bar {
 		$wp_customize->add_setting( 'sfb_background_color', array(
 			'default'			=> '#2c2d33',
 			'sanitize_callback'	=> 'sanitize_hex_color',
-			'transport'			=> 'postMessage', // Refreshes instantly via js. See customizer.js. (default = refresh).
 		) );
 
 		$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'sfb_background_color', array(
@@ -312,7 +310,6 @@ final class Storefront_Footer_Bar {
 		$wp_customize->add_setting( 'sfb_heading_color', array(
 			'default'           => '#ffffff',
 			'sanitize_callback'	=> 'sanitize_hex_color',
-			'transport'	        => 'postMessage', // Refreshes instantly via js. See customizer.js. (default = refresh).
 		) );
 
 		$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'sfb_heading_color', array(
@@ -328,7 +325,6 @@ final class Storefront_Footer_Bar {
 		$wp_customize->add_setting( 'sfb_text_color', array(
 			'default'           => '#9aa0a7',
 			'sanitize_callback'	=> 'sanitize_hex_color',
-			'transport'	        => 'postMessage', // Refreshes instantly via js. See customizer.js. (default = refresh).
 		) );
 
 		$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'sfb_text_color', array(
@@ -395,15 +391,6 @@ final class Storefront_Footer_Bar {
 		}
 
 		wp_add_inline_style( 'sfb-styles', $sfb_style );
-	}
-
-	/**
-	 * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
-	 *
-	 * @since  1.0.0
-	 */
-	public function sfb_customize_preview_js() {
-		wp_enqueue_script( 'sfb-customizer', plugins_url( '/assets/js/customizer.min.js', __FILE__ ), array( 'customize-preview' ), '1.1', true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #16 / Depends on #17 

Remove obsolete custom JS file for preview in the Customizer.

### Screenshots

n/a

### How to test the changes in this Pull Request:

1. Install and activate the Storefront theme
2. Install and activate the Storefront Footer Bar extension
3. Go to Appearance → Customize → Widgets → Footer Bar
4. Add a widget/block of your choice, e.g. the Meta widget/block
5. Go to Appearance → Customize → Footer Bar
6. Adjust the background, heading and text color
7. See the result in the Customizer
8. Check out this PR
9. Adjust the background, heading and text color
10. See that the result in the Customizer is the same as before

### Changelog

> Remove obsolete JS file.

### Tests

- [ ] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Notes

https://github.com/woocommerce/storefront-footer-bar/issues/16 had been created to replace the deprecated jQuery call `.bind()`. Looking at https://github.com/woocommerce/storefront-footer-bar/blob/trunk/assets/js/customizer.js, I noticed that the purpose of this file is to preview color changes of the Footer Bar in the Customizer. 

As the Customizer contains functionality to preview changes by default, I decided not to replace the deprecated jQuery call `.bind()`, but to remove the file https://github.com/woocommerce/storefront-footer-bar/blob/trunk/assets/js/customizer.js instead. 

@jconroy What do you think about this approach? My intension was to keep the plugin as lean as possible and only add functionality that is really needed.